### PR TITLE
Use static linking when compiling for ARM

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -23,13 +23,14 @@
                 ],
               },
             }
-        },
-        {
+          },
+          {
             "dependencies": [
               "deps/sqlite3.gyp:sqlite3"
             ]
-        }
-        ]
+          }
+        ],
+        [ "target_arch=='arm'", {"type": "static_library"} ]
       ],
       "sources": [
         "src/database.cc",


### PR DESCRIPTION
When cross-compiling VSCode for ARM, the sqlite binding fails with `relocation R_ARM_THM_MOVW_ABS_NC against '_LIB_VERSION' can not be used when making a shared object`.

Code that uses this instruction must be compiled as a static library/archive. This PR updates the gyp config to do that when targeting ARM architectures.

The same addition was previously necessary in Atom's keytar bindings around a year ago:
https://github.com/atom/node-keytar/blob/master/binding.gyp#L51