### PR TITLE
Fix ARM build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -29,7 +29,8 @@
               "deps/sqlite3.gyp:sqlite3"
             ]
         }
-        ]
+        ],
+        [ "target_arch=='arm'", {"type": "static_library"} ]
       ],
       "sources": [
         "src/database.cc",


### PR DESCRIPTION
This is a corrected PR to use static linking when cross-compiling for ARM, as it otherwise fails with `relocation R_ARM_THM_MOVW_ABS_NC against '_LIB_VERSION' can not be used when making a shared object`.

Per https://github.com/Microsoft/vscode-node-sqlite3/pull/1#issuecomment-440210045, PR should merge into the `vscode` branch. Whitespace fix has also been removed to stay as inline as possible with upstream.