### PR TITLE
Backport: overwrite 'msbuild_toolset' only if 'toolset' is defined

### DIFF
--- a/deps/common-sqlite.gypi
+++ b/deps/common-sqlite.gypi
@@ -5,7 +5,11 @@
   },
   'target_defaults': {
     'default_configuration': 'Release',
-    'msbuild_toolset':'<(toolset)',
+    'conditions': [
+      [ 'toolset!=""', {
+        'msbuild_toolset':'<(toolset)'
+      }]
+    ],
     'configurations': {
       'Debug': {
         'defines!': [


### PR DESCRIPTION
See the original PR for details: https://github.com/mapbox/node-sqlite3/pull/1242

Tested by doing a complete build of Visual Studio Code for Windows on Arm. 