### PR TITLE
sqlite3.gyp quotes error

### DIFF
--- a/deps/sqlite3.gyp
+++ b/deps/sqlite3.gyp
@@ -62,7 +62,7 @@
           ],
           # Use the python executable found by node-gyp
           # https://github.com/nodejs/node-gyp/blob/91eb407f8418235d51c72b6a8df9c454ba882554/lib/configure.js#L25-L36
-          'action': ['<!(node -p "process.env.PYTHON")','./extract.py','./sqlite-autoconf-<@(sqlite_version).tar.gz','<(SHARED_INTERMEDIATE_DIR)']
+          'action': ['"<!(node -p "process.env.PYTHON")"','./extract.py','./sqlite-autoconf-<@(sqlite_version).tar.gz','<(SHARED_INTERMEDIATE_DIR)']
         }
       ],
       'direct_dependent_settings': {


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/152839#issuecomment-1180227174
'C:\Program' is not recognized as an internal or external command,`

___

why was https://www.npmjs.com/package/sqlite3 forked ?
for performance ? I see that dependency: ` "@mapbox/node-pre-gyp": "^1.0.0",` is removed

note that sqlite3 was updated from `./extract.py` to `./extract.js`
https://github.com/TryGhost/node-sqlite3/pull/1570
so my "fix" is totally useless if we merge with sqlite3
