### PR TITLE
:up: sqlite3@5.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ vscode ]
   pull_request:
-    branches: [ * ]
 
 jobs:
   posix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,174 +1,27 @@
-name: CI
+name: Electron CI
+
 on:
-  workflow_dispatch:
-  pull_request:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
-env:
-  FORCE_COLOR: 1
-concurrency:
-  group: ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+    branches: [ vscode ]
+  pull_request:
+    branches: [ * ]
+
 jobs:
-  build:
+  posix:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-          - windows-latest
-        host:
-          - x64
-        target:
-          - x64
-        node:
-          - 10
-          - 11
-          - 12
-          - 13
-          - 14
-          - 15
-          - 16
-          - 17
-          - 18
-        include:
-          - os: windows-latest
-            node: 16
-            host: x86
-            target: x86
-          - os: macos-m1
-            node: 16
-            host: arm64
-            target: arm64
-    name: ${{ matrix.os }} (node=${{ matrix.node }}, host=${{ matrix.host }}, target=${{ matrix.target }})
+        os: [macos-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node }}
-          architecture: ${{ matrix.host }}
-
-      - name: Add yarn (self-hosted)
-        if: matrix.os == 'macos-m1'
-        run: npm install -g yarn
-
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.1
-        if: contains(matrix.os, 'windows')
-        with:
-          msbuild-architecture: ${{ matrix.target }}
-
-      - name: Install dependencies
-        run: yarn install --ignore-scripts
-
-      - name: Add env vars
-        shell: bash
-        run: |
-          echo "V=1" >> $GITHUB_ENV
-
-          if [ "${{ matrix.target }}" = "x86" ]; then
-            echo "TARGET=ia32" >> $GITHUB_ENV
-          else
-            echo "TARGET=${{ matrix.target }}" >> $GITHUB_ENV
-          fi
-
-      - name: Add Linux env vars
-        if: contains(matrix.os, 'ubuntu')
-        run: |
-          echo "CFLAGS=${CFLAGS:-} -include ../src/gcc-preinclude.h" >> $GITHUB_ENV
-          echo "CXXFLAGS=${CXXFLAGS:-} -include ../src/gcc-preinclude.h" >> $GITHUB_ENV
-
-      - name: Configure build
-        run: yarn node-pre-gyp configure --target_arch=${{ env.TARGET }}
-
-      - name: Build binaries
-        run: yarn node-pre-gyp build --target_arch=${{ env.TARGET }}
-
-      - name: Print binary info
-        if: contains(matrix.os, 'ubuntu')
-        run: |
-          ldd lib/binding/*/node_sqlite3.node
-          echo "---"
-          nm lib/binding/*/node_sqlite3.node | grep "GLIBC_" | c++filt || true
-          echo "---"
-          file lib/binding/napi-v*/*
-
-      - name: Run tests
-        run: yarn test
-
-      - name: Package prebuilt binaries
-        run: yarn node-pre-gyp package --target_arch=${{ env.TARGET }}
-
-      - name: Upload binaries to commit artifacts
-        uses: actions/upload-artifact@v3
-        if: matrix.node == 16
-        with:
-          name: prebuilt-binaries
-          path: build/stage/*/*
-          retention-days: 7
-
-      - name: Upload binaries to GitHub Release
-        run: yarn node-pre-gyp-github publish
-        if: matrix.node == 16 && startsWith(github.ref, 'refs/tags/')
-        env:
-          NODE_PRE_GYP_GITHUB_TOKEN: ${{ github.token }}
-  build-qemu:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+    - uses: actions/checkout@v2
+    - run: yarn install
+    - run: scripts/test-electron.sh
+  windows:
+    runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
-        node:
-          - 16
-        target:
-          - linux/arm64
-        variant:
-          - bullseye
-          - alpine3.15
-        include:
-          # musl x64 builds
-          - target: linux/amd64
-            variant: alpine3.15
-            node: 16
-    name: ${{ matrix.variant }} (node=${{ matrix.node }}, target=${{ matrix.target }})
+        os: [windows-latest]
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build binaries and test
-        run: |
-          docker buildx build \
-            --file ./tools/BinaryBuilder.Dockerfile \
-            --load \
-            --tag sqlite-builder \
-            --platform ${{ matrix.target }} \
-            --no-cache \
-            --build-arg VARIANT=${{ matrix.variant }} \
-            --build-arg NODE_VERSION=${{ matrix.node }} \
-            .
-          CONTAINER_ID=$(docker create -it sqlite-builder)
-          docker cp $CONTAINER_ID:/usr/src/build/build/ ./build
-
-      - name: Upload binaries to commit artifacts
-        uses: actions/upload-artifact@v3
-        if: matrix.node == 16
-        with:
-          name: prebuilt-binaries
-          path: build/stage/*/*
-          retention-days: 7
-
-      - name: Upload binaries to GitHub Release
-        run: yarn install --ignore-scripts && yarn node-pre-gyp-github publish
-        if: matrix.node == 16 && startsWith(github.ref, 'refs/tags/')
-        env:
-          NODE_PRE_GYP_GITHUB_TOKEN: ${{ github.token }}
+    - uses: actions/checkout@v2
+    - run: yarn install
+    - run: .\scripts\test-electron.bat

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,3 @@
+disturl "https://electronjs.org/headers"
+target "19.1.3"
+runtime "electron"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+<!-- BEGIN MICROSOFT SECURITY.MD V0.0.5 BLOCK -->
+
+## Security
+
+Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
+
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
+
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
+
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://microsoft.com/msrc/bounty) page for more details about our active programs.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Policy
+
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/en-us/msrc/cvd).
+
+<!-- END MICROSOFT SECURITY.MD BLOCK -->

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,15 +6,28 @@
   },
   "targets": [
     {
-      "target_name": "<(module_name)",
+      "target_name": "vscode-sqlite3",
       "cflags!": [ "-fno-exceptions" ],
       "cflags_cc!": [ "-fno-exceptions" ],
       "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
         "CLANG_CXX_LIBRARY": "libc++",
-        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+        # Target depends on
+        # https://chromium.googlesource.com/chromium/src/+/master/build/config/mac/mac_sdk.gni#22
+        "MACOSX_DEPLOYMENT_TARGET": "10.11",
       },
       "msvs_settings": {
-        "VCCLCompilerTool": { "ExceptionHandling": 1 },
+        "VCCLCompilerTool": {
+          "ExceptionHandling": 1,
+          "AdditionalOptions": [
+            '/Qspectre',
+            '/guard:cf'
+          ]
+        },
+        "VCLinkerTool": {
+          "AdditionalOptions": [
+            '/guard:cf'
+          ]
+        }
       },
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include\")"],
@@ -49,18 +62,18 @@
         "src/node_sqlite3.cc",
         "src/statement.cc"
       ],
-      "defines": [ "NAPI_VERSION=<(napi_build_version)", "NAPI_DISABLE_CPP_EXCEPTIONS=1" ]
+      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS=1", "NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS" ]
     },
-    {
-      "target_name": "action_after_build",
-      "type": "none",
-      "dependencies": [ "<(module_name)" ],
-      "copies": [
-          {
-            "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
-            "destination": "<(module_path)"
-          }
-      ]
-    }
+    #{
+    #  "target_name": "action_after_build",
+    #  "type": "none",
+    #  "dependencies": [ "<(module_name)" ],
+    #  "copies": [
+    #      {
+    #        "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
+    #        "destination": "<(module_path)"
+    #      }
+    #  ]
+    #}
   ]
 }

--- a/lib/sqlite3-binding.js
+++ b/lib/sqlite3-binding.js
@@ -1,5 +1,5 @@
-const binary = require('@mapbox/node-pre-gyp');
+/*const binary = require('@mapbox/node-pre-gyp');
 const path = require('path');
-const binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json')));
-const binding = require(binding_path);
+const binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json')));*/
+const binding = require('../build/Release/vscode-sqlite3.node');
 module.exports = exports = binding;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vscode/sqlite3",
   "description": "Asynchronous, non-blocking SQLite3 bindings",
-  "version": "5.1.3",
+  "version": "5.1.2",
   "homepage": "https://github.com/microsoft/vscode-node-sqlite3",
   "author": {
     "name": "Mapbox",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "sqlite3",
+  "name": "@vscode/sqlite3",
   "description": "Asynchronous, non-blocking SQLite3 bindings",
-  "version": "5.1.2",
-  "homepage": "https://github.com/TryGhost/node-sqlite3",
+  "version": "5.1.3",
+  "homepage": "https://github.com/microsoft/vscode-node-sqlite3",
   "author": {
     "name": "Mapbox",
     "url": "https://mapbox.com/"
@@ -45,33 +45,18 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/TryGhost/node-sqlite3.git"
+    "url": "https://github.com/microsoft/vscode-node-sqlite3.git"
   },
   "dependencies": {
-    "@mapbox/node-pre-gyp": "^1.0.0",
-    "node-addon-api": "^4.2.0",
-    "tar": "^6.1.11"
+    "node-addon-api": "^4.2.0"
   },
   "devDependencies": {
-    "eslint": "6.8.0",
+    "electron": "19.1.3",
+    "eslint": "^7.32.0",
     "mocha": "7.2.0",
-    "node-pre-gyp-github": "1.4.4"
-  },
-  "peerDependencies": {
-    "node-gyp": "8.x"
-  },
-  "peerDependenciesMeta": {
-    "node-gyp": {
-      "optional": true
-    }
-  },
-  "optionalDependencies": {
-    "node-gyp": "8.x"
+    "tar": "^6.1.11"
   },
   "scripts": {
-    "build": "node-pre-gyp build",
-    "build:debug": "node-pre-gyp build --debug",
-    "install": "node-pre-gyp install --fallback-to-build",
     "pretest": "node test/support/createdb.js",
     "test": "mocha -R spec --timeout 480000",
     "pack": "node-pre-gyp package"

--- a/scripts/test-electron.bat
+++ b/scripts/test-electron.bat
@@ -1,0 +1,13 @@
+@echo off
+setlocal
+
+pushd %~dp0\..
+
+set ELECTRON_RUN_AS_NODE=1 
+
+call .\node_modules\.bin\electron .\test\support/createdb.js
+call .\node_modules\.bin\electron .\node_modules\.bin\mocha -R spec --timeout 480000
+
+popd
+
+endlocal

--- a/scripts/test-electron.sh
+++ b/scripts/test-electron.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+export ELECTRON_RUN_AS_NODE=1 
+
+./node_modules/.bin/electron ./test/support/createdb.js
+./node_modules/.bin/electron ./node_modules/.bin/mocha -R spec --timeout 480000

--- a/src/database.cc
+++ b/src/database.cc
@@ -172,6 +172,11 @@ void Database::Work_Open(napi_env e, void* data) {
     );
 
     if (baton->status != SQLITE_OK) {
+        // Get the extended error code since this error happened
+        // during open where sqlite3_extended_result_codes was
+        // not called yet. We overwrite the status with the extended
+        // code to ensure we can produce a more detailed error.
+        baton->status = sqlite3_extended_errcode(db->_handle);
         baton->message = std::string(sqlite3_errmsg(db->_handle));
         sqlite3_close(db->_handle);
         db->_handle = NULL;
@@ -179,6 +184,9 @@ void Database::Work_Open(napi_env e, void* data) {
     else {
         // Set default database handle values.
         sqlite3_busy_timeout(db->_handle, 1000);
+
+        // Enable extended error codes.
+        sqlite3_extended_result_codes(db->_handle, 1);
     }
 }
 

--- a/src/node_sqlite3.cc
+++ b/src/node_sqlite3.cc
@@ -83,6 +83,8 @@ Napi::Object RegisterModule(Napi::Env env, Napi::Object exports) {
 
 const char* sqlite_code_string(int code) {
     switch (code) {
+        
+        // Basic Codes
         case SQLITE_OK:         return "SQLITE_OK";
         case SQLITE_ERROR:      return "SQLITE_ERROR";
         case SQLITE_INTERNAL:   return "SQLITE_INTERNAL";
@@ -112,6 +114,74 @@ const char* sqlite_code_string(int code) {
         case SQLITE_NOTADB:     return "SQLITE_NOTADB";
         case SQLITE_ROW:        return "SQLITE_ROW";
         case SQLITE_DONE:       return "SQLITE_DONE";
+
+        // Extended Codes
+        case SQLITE_ERROR_MISSING_COLLSEQ:      return "SQLITE_ERROR_MISSING_COLLSEQ";
+        case SQLITE_ERROR_RETRY:                return "SQLITE_ERROR_RETRY";
+        case SQLITE_IOERR_READ:                 return "SQLITE_IOERR_READ";
+        case SQLITE_IOERR_SHORT_READ:           return "SQLITE_IOERR_SHORT_READ";
+        case SQLITE_IOERR_WRITE:                return "SQLITE_IOERR_WRITE";
+        case SQLITE_IOERR_FSYNC:                return "SQLITE_IOERR_FSYNC";
+        case SQLITE_IOERR_DIR_FSYNC:            return "SQLITE_IOERR_DIR_FSYNC";
+        case SQLITE_IOERR_TRUNCATE:             return "SQLITE_IOERR_TRUNCATE";
+        case SQLITE_IOERR_FSTAT:                return "SQLITE_IOERR_FSTAT";
+        case SQLITE_IOERR_UNLOCK:               return "SQLITE_IOERR_UNLOCK";
+        case SQLITE_IOERR_RDLOCK:               return "SQLITE_IOERR_RDLOCK";
+        case SQLITE_IOERR_DELETE:               return "SQLITE_IOERR_DELETE";
+        case SQLITE_IOERR_BLOCKED:              return "SQLITE_IOERR_BLOCKED";
+        case SQLITE_IOERR_NOMEM:                return "SQLITE_IOERR_NOMEM";
+        case SQLITE_IOERR_ACCESS:               return "SQLITE_IOERR_ACCESS";
+        case SQLITE_IOERR_CHECKRESERVEDLOCK:    return "SQLITE_IOERR_CHECKRESERVEDLOCK";
+        case SQLITE_IOERR_LOCK:                 return "SQLITE_IOERR_LOCK";
+        case SQLITE_IOERR_CLOSE:                return "SQLITE_IOERR_CLOSE";
+        case SQLITE_IOERR_DIR_CLOSE:            return "SQLITE_IOERR_DIR_CLOSE";
+        case SQLITE_IOERR_SHMOPEN:              return "SQLITE_IOERR_SHMOPEN";
+        case SQLITE_IOERR_SHMSIZE:              return "SQLITE_IOERR_SHMSIZE";
+        case SQLITE_IOERR_SHMLOCK:              return "SQLITE_IOERR_SHMLOCK";
+        case SQLITE_IOERR_SHMMAP:               return "SQLITE_IOERR_SHMMAP";
+        case SQLITE_IOERR_SEEK:                 return "SQLITE_IOERR_SEEK";
+        case SQLITE_IOERR_DELETE_NOENT:         return "SQLITE_IOERR_DELETE_NOENT";
+        case SQLITE_IOERR_MMAP:                 return "SQLITE_IOERR_MMAP";
+        case SQLITE_IOERR_GETTEMPPATH:          return "SQLITE_IOERR_GETTEMPPATH";
+        case SQLITE_IOERR_CONVPATH:             return "SQLITE_IOERR_CONVPATH";
+        case SQLITE_IOERR_VNODE:                return "SQLITE_IOERR_VNODE";
+        case SQLITE_IOERR_AUTH:                 return "SQLITE_IOERR_AUTH";
+        case SQLITE_IOERR_BEGIN_ATOMIC:         return "SQLITE_IOERR_BEGIN_ATOMIC";
+        case SQLITE_IOERR_COMMIT_ATOMIC:        return "SQLITE_IOERR_COMMIT_ATOMIC";
+        case SQLITE_IOERR_ROLLBACK_ATOMIC:      return "SQLITE_IOERR_ROLLBACK_ATOMIC";
+        case SQLITE_LOCKED_SHAREDCACHE:         return "SQLITE_LOCKED_SHAREDCACHE";
+        case SQLITE_LOCKED_VTAB:                return "SQLITE_LOCKED_VTAB";
+        case SQLITE_BUSY_RECOVERY:              return "SQLITE_BUSY_RECOVERY";
+        case SQLITE_BUSY_SNAPSHOT:              return "SQLITE_BUSY_SNAPSHOT";
+        case SQLITE_CANTOPEN_NOTEMPDIR:         return "SQLITE_CANTOPEN_NOTEMPDIR";
+        case SQLITE_CANTOPEN_ISDIR:             return "SQLITE_CANTOPEN_ISDIR";
+        case SQLITE_CANTOPEN_FULLPATH:          return "SQLITE_CANTOPEN_FULLPATH";
+        case SQLITE_CANTOPEN_CONVPATH:          return "SQLITE_CANTOPEN_CONVPATH";
+        case SQLITE_CORRUPT_VTAB:               return "SQLITE_CORRUPT_VTAB";
+        case SQLITE_CORRUPT_SEQUENCE:           return "SQLITE_CORRUPT_SEQUENCE";
+        case SQLITE_READONLY_RECOVERY:          return "SQLITE_READONLY_RECOVERY";
+        case SQLITE_READONLY_CANTLOCK:          return "SQLITE_READONLY_CANTLOCK";
+        case SQLITE_READONLY_ROLLBACK:          return "SQLITE_READONLY_ROLLBACK";
+        case SQLITE_READONLY_DBMOVED:           return "SQLITE_READONLY_DBMOVED";
+        case SQLITE_READONLY_CANTINIT:          return "SQLITE_READONLY_CANTINIT";
+        case SQLITE_READONLY_DIRECTORY:         return "SQLITE_READONLY_DIRECTORY";
+        case SQLITE_ABORT_ROLLBACK:             return "SQLITE_ABORT_ROLLBACK";
+        case SQLITE_CONSTRAINT_CHECK:           return "SQLITE_CONSTRAINT_CHECK";
+        case SQLITE_CONSTRAINT_COMMITHOOK:      return "SQLITE_CONSTRAINT_COMMITHOOK";
+        case SQLITE_CONSTRAINT_FOREIGNKEY:      return "SQLITE_CONSTRAINT_FOREIGNKEY";
+        case SQLITE_CONSTRAINT_FUNCTION:        return "SQLITE_CONSTRAINT_FUNCTION";
+        case SQLITE_CONSTRAINT_NOTNULL:         return "SQLITE_CONSTRAINT_NOTNULL";
+        case SQLITE_CONSTRAINT_PRIMARYKEY:      return "SQLITE_CONSTRAINT_PRIMARYKEY";
+        case SQLITE_CONSTRAINT_TRIGGER:         return "SQLITE_CONSTRAINT_TRIGGER";
+        case SQLITE_CONSTRAINT_UNIQUE:          return "SQLITE_CONSTRAINT_UNIQUE";
+        case SQLITE_CONSTRAINT_VTAB:            return "SQLITE_CONSTRAINT_VTAB";
+        case SQLITE_CONSTRAINT_ROWID:           return "SQLITE_CONSTRAINT_ROWID";
+        case SQLITE_NOTICE_RECOVER_WAL:         return "SQLITE_NOTICE_RECOVER_WAL";
+        case SQLITE_NOTICE_RECOVER_ROLLBACK:    return "SQLITE_NOTICE_RECOVER_ROLLBACK";
+        case SQLITE_WARNING_AUTOINDEX:          return "SQLITE_WARNING_AUTOINDEX";
+        case SQLITE_AUTH_USER:                  return "SQLITE_AUTH_USER";
+        case SQLITE_OK_LOAD_PERMANENTLY:        return "SQLITE_OK_LOAD_PERMANENTLY";
+
         default:                return "UNKNOWN";
     }
 }


### PR DESCRIPTION
Bring us up to date with https://github.com/TryGhost/node-sqlite3 with the following changes:
* drop `node-pre-gyp` so that the library is built natively
* add workflows for Electron testing
* preserve extended error codes
* some tweaks to native building