### PR TITLE
fix: add flags for sqlite3 dep

### DIFF
--- a/deps/sqlite3.gyp
+++ b/deps/sqlite3.gyp
@@ -33,6 +33,10 @@
     },
     'msvs_settings': {
       'VCCLCompilerTool': {
+        "AdditionalOptions": [
+          "/w34244",
+          "/we4267"
+        ]
       },
       'VCLibrarianTool': {
       },


### PR DESCRIPTION
I'm not sure whether this is necessary, but we still have a Binskim alert for the sqlite3 object itself due to the sqlite3 dep not having the warnings explicitly enabled.

@deepak1556 Let me know if this should be a wontfix.