### PR TITLE
fix: node-addon-api exception handling

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,20 +7,20 @@
   "targets": [
     {
       "target_name": "vscode-sqlite3",
-      "cflags!": [ "-fno-exceptions" ],
-      "cflags_cc!": [ "-fno-exceptions" ],
-      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+      "xcode_settings": {
         "CLANG_CXX_LIBRARY": "libc++",
         # Target depends on
         # https://chromium.googlesource.com/chromium/src/+/master/build/config/mac/mac_sdk.gni#22
         "MACOSX_DEPLOYMENT_TARGET": "10.11",
       },
+      "dependencies": [
+        "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except"
+      ],
       "msvs_configuration_attributes": {
         "SpectreMitigation": "Spectre"
       },
       "msvs_settings": {
         "VCCLCompilerTool": {
-          "ExceptionHandling": 1,
           "AdditionalOptions": [
             "/guard:cf",
             "/w34244",
@@ -67,7 +67,7 @@
         "src/node_sqlite3.cc",
         "src/statement.cc"
       ],
-      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS=1", "NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS" ]
+      "defines": [ "NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS" ]
     },
     #{
     #  "target_name": "action_after_build",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vscode/sqlite3",
   "description": "Asynchronous, non-blocking SQLite3 bindings",
-  "version": "5.1.7-vscode",
+  "version": "5.1.8-vscode",
   "homepage": "https://github.com/microsoft/vscode-node-sqlite3",
   "author": {
     "name": "Mapbox",


### PR DESCRIPTION
Properly defines exception handling story, see https://github.com/nodejs/node-addon-api/blob/main/doc/error_handling.md for context