### PR TITLE
chore: add stack-protector-strong flag

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -17,6 +17,7 @@
         "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except"
       ],
       "cflags": [
+        "-fstack-protector-strong",
         "-O2"
       ],
       "msvs_configuration_attributes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/sqlite3",
-  "version": "5.1.11-vscode",
+  "version": "5.1.12-vscode",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/sqlite3",
-      "version": "5.1.11-vscode",
+      "version": "5.1.12-vscode",
       "license": "BSD-3-Clause",
       "dependencies": {
         "node-addon-api": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vscode/sqlite3",
   "description": "Asynchronous, non-blocking SQLite3 bindings",
-  "version": "5.1.11-vscode",
+  "version": "5.1.12-vscode",
   "homepage": "https://github.com/microsoft/vscode-node-sqlite3",
   "author": {
     "name": "Mapbox",


### PR DESCRIPTION
This PR adds the stack-protector-strong flag. Considering the performance testing results in https://github.com/microsoft/node-spdlog/pull/63, and that this library is not called as frequently as spdlog, I do not believe that this library requires performance testing.